### PR TITLE
Adding support for custom port

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,9 @@ const Jarvis = require('webpack-jarvis');
 // the rest of your webpack configs
 
 plugins: [
-    new Jarvis() // that's all you need!
+    new Jarvis({
+      port: 1337 // optional: set a port
+    })
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ In your webpack config file:
 ```
 const Jarvis = require('webpack-jarvis');
 
-// the rest of your webpack configs
+/* the rest of your webpack configs */
 
 plugins: [
     new Jarvis({

--- a/src/client/components/board.js
+++ b/src/client/components/board.js
@@ -10,7 +10,7 @@ import { readableBytes } from "../helpers/utils";
 import Nav from "./nav";
 
 import io from "socket.io-client";
-const socket = io("localhost:1337");
+const socket = io("localhost:" + document.location.port);
 
 export default class Board extends Component {
   state = {

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -5,9 +5,7 @@ const importCwd = require("import-cwd"); // used to get the users project detail
 
 const pkg = importCwd("./package.json");
 
-function Jarvis(opts) {
-  
-  const options = opts || {};
+function Jarvis(options = {}) {
   
   // check if port is valid
   let portIsValid = true;

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -6,9 +6,19 @@ const importCwd = require("import-cwd"); // used to get the users project detail
 const pkg = importCwd("./package.json");
 
 function Jarvis(options) {
+
+  // check if port is valid
+  let portIsValid = true;
+  if (options && options.port && isNaN(parseInt(options.port))) {
+    portIsValid = false;
+    console.error(`[JARVIS] your specified port ("${options.port}") is invalid, falling back to 1337, please check it again :)`);
+  };
+
   this.options = {
-    port: options && options.port || 1337 // if no port specified fall back to 1337
-  }
+    port: (options && portIsValid)
+      ? parseInt(options.port)
+      : 1337 // fall back to 1337 if port is not a number
+  };
   this.env = {
     production: false,
     running: false, // indicator if our express server + sockets are running
@@ -21,7 +31,7 @@ function Jarvis(options) {
   };
 }
 
-Jarvis.prototype.apply = function (compiler) {
+Jarvis.prototype.apply = function(compiler) {
   let projectInfo = {
     name: pkg.name,
     version: pkg.version,

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -5,17 +5,19 @@ const importCwd = require("import-cwd"); // used to get the users project detail
 
 const pkg = importCwd("./package.json");
 
-function Jarvis(options) {
-
+function Jarvis(opts) {
+  
+  const options = opts || {};
+  
   // check if port is valid
   let portIsValid = true;
-  if (options && options.port && isNaN(parseInt(options.port))) {
+  if (options.port && isNaN(parseInt(options.port))) {
     portIsValid = false;
     console.error(`[JARVIS] your specified port ("${options.port}") is invalid, falling back to 1337, please check it again :)`);
   };
 
   this.options = {
-    port: (options && portIsValid)
+    port: (portIsValid)
       ? parseInt(options.port)
       : 1337 // fall back to 1337 if port is not a number
   };

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -6,18 +6,9 @@ const importCwd = require("import-cwd"); // used to get the users project detail
 const pkg = importCwd("./package.json");
 
 function Jarvis(options = {}) {
-  
-  // check if port is valid
-  let portIsValid = true;
-  if (isNaN(parseInt(options.port))) {
-    portIsValid = false;
-    console.error(`[JARVIS] your specified port ("${options.port}") is invalid, falling back to 1337, please check it again :)`);
-  };
 
   this.options = {
-    port: (portIsValid)
-      ? parseInt(options.port)
-      : 1337 // fall back to 1337 if port is not a number
+    port: options.port || 1337 // fall back to 1337 if port is not a number
   };
   this.env = {
     production: false,

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -6,7 +6,9 @@ const importCwd = require("import-cwd"); // used to get the users project detail
 const pkg = importCwd("./package.json");
 
 function Jarvis(options) {
-  // TOOD: add options for port, etc..
+  this.options = {
+    port: options && options.port || 1337 // if no port specified fall back to 1337
+  }
   this.env = {
     production: false,
     running: false, // indicator if our express server + sockets are running
@@ -19,7 +21,7 @@ function Jarvis(options) {
   };
 }
 
-Jarvis.prototype.apply = function(compiler) {
+Jarvis.prototype.apply = function (compiler) {
   let projectInfo = {
     name: pkg.name,
     version: pkg.version,
@@ -29,7 +31,7 @@ Jarvis.prototype.apply = function(compiler) {
   this.reports.projcect = projectInfo;
 
   if (!this.env.running) {
-    server.start(() => {
+    server.start(this.options, () => {
       this.env.running = true;
       // if a new client is connected push current bundle info
       server.io.on("connection", socket => {

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -8,7 +8,9 @@ const pkg = importCwd("./package.json");
 function Jarvis(options = {}) {
 
   this.options = {
-    port: options.port || 1337 // fall back to 1337 if port is not a number
+    port: (isNaN(parseInt(options.port))) // if port is not a number console.error if port is port given in config and fall back to 1337
+      ? (options.port && console.error(`[JARVIS] error: the specified port (${options.port}) is not valid, falling back to 1337...`) && false) || 1337
+      : options.port
   };
   this.env = {
     production: false,

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -9,7 +9,7 @@ function Jarvis(options = {}) {
   
   // check if port is valid
   let portIsValid = true;
-  if (options.port && isNaN(parseInt(options.port))) {
+  if (isNaN(parseInt(options.port))) {
     portIsValid = false;
     console.error(`[JARVIS] your specified port ("${options.port}") is invalid, falling back to 1337, please check it again :)`);
   };

--- a/src/plugin/server.js
+++ b/src/plugin/server.js
@@ -23,6 +23,8 @@ const app = express();
 const server = http.Server(app);
 const io = socket(server);
 
+let PORT = undefined;
+
 exports.io = io;
 
 if (process.env.NODE_ENV !== "jarvis_dev") {
@@ -31,12 +33,15 @@ if (process.env.NODE_ENV !== "jarvis_dev") {
     res.sendFile(path.join(__dirname + "../../dist/bin/index.html"))
   );
 } else {
-  app.get("/", (_, res) => res.send("Jarvis client is running on: 1337"));
+  app.get("/", (_, res) => res.send(`Jarvis client is running on: ${PORT}`));
 }
 
-const start = next => {
-  return server.listen(1337, () => {
-    console.log("Starting JARVIS on: http://localhost:1337");
+const start = (options, next) => {
+
+  PORT = options.port;
+
+  return server.listen(PORT, () => {
+    console.log(`[JARVIS] Starting dashboard on: http://localhost:${PORT}`);
     next();
   });
 };


### PR DESCRIPTION
Hi, I just found this beautiful dashboard but was wondering why I wasn't able to set a custom port so I quickly changed a few lines of code and added it to the README.  Now you can specify a port by adding the plugin like this:
```javascript
new Jarvis({
    port: 1337
})
```
this PR should also resolve #32 
I quickly tested that everything works and it falls back to `1337` if no port is given.