### PR TITLE
Add OSSNINJA MIT License and refactor .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Yarn files
+yarn.lock
+.yarn-integrity
+
+# Optional npm cache directory
+.npm
+
+# dotenv environment variables file
+.env
+
+# misc
+.DS_*
+.idea/
+dist/
+bin
+.DS_Store
+.idea
+.vscode
+
 # Logs
 logs
 *.log
@@ -20,45 +43,14 @@ coverage
 # nyc test coverage
 .nyc_output
 
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-
-# Bower dependency directory (https://bower.io/)
-bower_components
-
 # node-waf configuration
 .lock-wscript
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directories
-node_modules/
-jspm_packages/
-
 # Typescript v1 declaration files
 typings/
 
-# Optional npm cache directory
-.npm
-
-# Optional eslint cache
-.eslintcache
-
-# Optional REPL history
-.node_repl_history
-
 # Output of 'npm pack'
 *.tgz
-
-# Yarn Integrity file
-.yarn-integrity
-
-# dotenv environment variables file
-.env
-
-# mac shit
-.DS_*
-/.idea
-dist/
-bin

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,0 @@
-Copyright (c) 
-2018
- 
-Zouhir
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
   <img src="https://github.com/zouhir/jarvis/blob/master/.github/readme-logo.png?raw=true">
 </h1>
 
-</br>
+<br />
 
-[![npm package](https://img.shields.io/npm/v/webpack-jarvis.svg)](https://www.npmjs.com/package/webpack-jarvis)
-[![npm package](https://img.shields.io/npm/dm/webpack-jarvis.svg)](https://www.npmjs.com/package/webpack-jarvis)
+<div align="center">
+  <a href="https://www.npmjs.com/package/webpack-jarvis">
+    <img src="https://img.shields.io/npm/v/webpack-jarvis.svg" alt="version" />
+  </a>
+  <a href="https://www.npmjs.com/package/webpack-jarvis">
+    <img src="https://img.shields.io/npm/dm/webpack-jarvis.svg" alt="version" />
+  </a>
+  <a href="https://oss.ninja/mit/zouhir">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" />
+  </a>
+</div>
 
-</br>
-</br>
+<br />
+<br />
 
 <p>
   <img src="https://github.com/zouhir/jarvis/blob/master/.github/readme-about.png?raw=true" width="100%">
@@ -55,7 +64,7 @@ $ npm i -D webpack-jarvis
 
 In your webpack config file:
 
-```javascript
+```js
 const Jarvis = require('webpack-jarvis');
 
 /* the rest of your webpack configs */
@@ -93,7 +102,6 @@ and you are all set!
 <p>
   <img src="https://github.com/zouhir/jarvis/blob/master/.github/readme-contrib.png?raw=true" width="100%">
 </p>
-
 _a super cool design will go here listing all contributors names + GitHub avatar_
 
 <br />
@@ -108,4 +116,4 @@ _a super cool design will go here listing all contributors names + GitHub avatar
   <img src="https://github.com/zouhir/jarvis/blob/master/.github/readme-license.png?raw=true" width="100%">
 </p>
 
-MIT © [Zouhir](https://zouhir.org)
+[MIT © Zouhir](https://oss.ninja/mit/zouhir)


### PR DESCRIPTION
Added OSSNINJA MIT License closes #37.

Refactored .gitignore a little and removed grunt and gulp. Made a separate commit for that just in case you did not like it.

I also tried adding [all-contributors](https://github.com/kentcdodds/all-contributors), but could not get it working. Will have a look later.