### PR TITLE
Trim Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "preact-compat": "^3.16.0",
     "preact-habitat": "^2.2.3",
     "preact-markup": "^1.6.0",
-    "socket.io": "^2.0.3",
-    "webpack-messages": "^1.0.0"
+    "socket.io": "^2.0.3"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",
@@ -68,7 +67,8 @@
     "style-loader": "^0.18.2",
     "svg-url-loader": "^2.1.1",
     "webpack": "^3.8.1",
-    "webpack-dev-server": "^2.9.3"
+    "webpack-dev-server": "^2.9.3",
+    "webpack-messages": "^1.0.0"
   },
   "lint-staged": {
     "*.{js,json,scss}": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "ansi-to-html": "^0.6.3",
     "express": "^4.15.4",
-    "import-cwd": "^2.1.0",
+    "import-from": "^2.1.0",
     "preact": "^8.2.1",
     "preact-compat": "^3.16.0",
     "preact-habitat": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
     "ansi-to-html": "^0.6.3",
     "express": "^4.15.4",
     "import-from": "^2.1.0",
-    "preact": "^8.2.1",
-    "preact-compat": "^3.16.0",
-    "preact-habitat": "^2.2.3",
-    "preact-markup": "^1.6.0",
     "socket.io": "^2.0.3"
   },
   "devDependencies": {
@@ -60,6 +56,10 @@
     "ncp": "^2.0.0",
     "node-sass": "^4.5.3",
     "postcss-loader": "^2.0.6",
+    "preact": "^8.2.1",
+    "preact-compat": "^3.16.0",
+    "preact-habitat": "^2.2.3",
+    "preact-markup": "^1.6.0",
     "prettier": "^1.10.2",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   },
   "dependencies": {
     "ansi-to-html": "^0.6.3",
-    "chalk": "^2.0.1",
-    "cwd": "^0.10.0",
     "express": "^4.15.4",
     "import-cwd": "^2.1.0",
     "preact": "^8.2.1",
@@ -32,8 +30,6 @@
     "preact-habitat": "^2.2.3",
     "preact-markup": "^1.6.0",
     "socket.io": "^2.0.3",
-    "webpack-dev-middleware": "^1.12.0",
-    "webpack-hot-middleware": "^2.20.0",
     "webpack-messages": "^1.0.0"
   },
   "devDependencies": {

--- a/src/client/webpack.config.js
+++ b/src/client/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const webpack = require("webpack");
-const chalk = require("chalk");
 const WebpackMessages = require("webpack-messages");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const autoprefixer = require("autoprefixer");

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -1,9 +1,9 @@
 const webpack = require("webpack");
 const server = require("./server"); // expreess and socket IO for the client
 const reporter = require("./reporter-util"); // webpack stats formatters & helpers
-const importCwd = require("import-cwd"); // used to get the users project details form their working dir
+const importFrom = require("import-from"); // used to get the users project details form their working dir
 
-const pkg = importCwd("./package.json");
+const pkg = importFrom(process.cwd(), "./package.json");
 
 function Jarvis(options) {
   // TOOD: add options for port, etc..

--- a/src/plugin/server.js
+++ b/src/plugin/server.js
@@ -8,7 +8,6 @@
 /**
  * External Dependencies
  */
-const cwd = require("cwd");
 const express = require("express");
 const http = require("http");
 const path = require("path");


### PR DESCRIPTION
Currently installing a lot more than needed.

Other thoughts:

- There's a duplicate `src/client/package.json` that's mostly the same as the root `package.json`. We should remove the one inside `src/client`, or move that entire directory into its own package to avoid confusion.

   - For example, a lot of these dependency changes were already done inside `client`'s but not the main one --- users install what the main one has defined.

    - I didn't touch the `src/clients/package.json` file...

- The NPM download includes `src` _and_ `bin` directories. We only need people to install the `bin` folder.

    - _Maybe `bin` should be renamed since it's no longer an executable?_

- All Preact packages are actually `devDependencies` since the client files aren't built when starting the plugin.

- The `import-cwd` module is a single-line-module that wraps `import-from`
    - TBH we don't need these at all. I find them really silly 😆 

The `package.json` now only installs the actual dependencies that the user will need.