### PR TITLE
Fix NPM download contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.1",
   "description": "A very intelligent webpack dashboard",
   "main": "bin/plugin/index.js",
+  "files": [
+    "bin"
+  ],
   "scripts": {
     "dev":
       "cross-env NODE_ENV=development webpack-dev-server --config='./src/client/webpack.config.js' --inline --hot --progress",


### PR DESCRIPTION
Only uploads the `bin` directory to NPM.

We'll only need to include the `src` directory if (when?) #33 shows that we need to build from scratch. If/When that happens, we can replace `bin` with `src` & still avoid duplicate content.

But, for now, this helps us out.