### PR TITLE
Fix some CSS issues with the table component

### DIFF
--- a/src/client/components/table/index.js
+++ b/src/client/components/table/index.js
@@ -81,9 +81,9 @@ export default class Table extends Component {
 
           {selected === "all" || selected === "mixed"
             ? table.mixed.map(module => (
-                <li>
+                <li className="flex-li">
                   <div className="col">
-                    {module.name}
+                    <p className="module-name">{module.name}</p>
                     <div className="details" />
                   </div>
                   <div className="col">{readableBytes(module.size)}</div>

--- a/src/client/components/table/style.scss
+++ b/src/client/components/table/style.scss
@@ -51,6 +51,26 @@
           width: 75%;
         }
       }
+      .flex-li {
+        display: flex;
+        .col {
+          position: static;
+          display: flex;
+          flex-grow: 1;
+          align-items: center;
+          .module-name {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+          .details {
+            position: static;
+            transform: none;
+            width: 60px;
+            margin-left: 5px;
+          }
+        }
+      }
     }
   }
 }

--- a/src/client/components/table/style.scss
+++ b/src/client/components/table/style.scss
@@ -13,6 +13,7 @@
   ul.table-body {
     height: 470px;
     overflow-y: scroll;
+    padding-bottom: 100px;
     .col {
       border-bottom: 1px solid $dark;
       border-top: 0px;


### PR DESCRIPTION
The first commit in this PR is to fix the overlapping module path and details (three dots) button. I've applied a small fix by overriding some styles, this isn't the best approach but I didn't want to entirely override all the other sections as well. If that's the preferred solution, i'm more than willing to do that as well. 

The second commit is a small fix to allow users to scroll all the way to the bottom of the list of modules in the table. Currently the last few modules in the list were hidden, therefore the padding allows the user to bring the last one into view.