### PR TITLE
[Technical Debt] Cleaning up the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is hugely inspired by other webpack dashboards and the core idea is not origi
 
 **Original Features**:
 
-* Shows you the count of ES Harmony module imports which can be treeshakable and the CJS ones which are not.
+* Shows you the count of ES Harmony module imports which can be treeshake-able and the CJS ones which are not.
 * Shows you how well your assets perform in 12 different connection types.
 
 **Other Features**:
@@ -80,15 +80,10 @@ and you are all set!
 
 **On the roadmap:**
 
-* Cleanup the hacky code in the client app, it's embarassing, I'm sorry!
 * Enforce best practices, structure and higher code quality standards.
 * Bundle size analyzer like feature in the table.
 * Build snippets page.
-* Build Oppurtunities Section to suggest loaders, plugins, etc. that can improve your build and bundle.
-
-**Note:**
-
-> I am not entirely sure how many bugs you will catch while it's in beta, but what I know for sure is the whole app, especially the client Preact app can be dramatically improved, JS & CSS and structure wise as the whole thing has been built in a rush in a very hacky way.
+* Build Opportunities Section to suggest loaders, plugins, etc. that can improve your build and bundle.
 
 ## Contributors
 


### PR DESCRIPTION
Here's my proposed plan for cleaning up the frontend.

I'd like to use [`recompose`](https://github.com/acdlite/recompose) to separate state management and presentational concerns and to tidy up individual components into smaller, testable functions.

I looked around the source and it's my opinion that we don't really need to use a full-fledged state management solution like [`redux`](https://redux.js.org/) because there don’t seem to be any large cross-cutting state-related issues that we need to solve. Not to mention that if these sort of issues come up in the future we can easily migrate to [`redux`](https://redux.js.org/) by way of breaking state logic up with [`recompose`](https://github.com/acdlite/recompose) anyway.

I also really want to add tests - possibly using a headless browser.

I would love to hear opinions from y'all on this.

Thank you @zouhir for the amazing work on this so far. If Webpack had a Hall of Fame, you'd have my vote to get in!