### PR TITLE
Fix Static Assets

### DIFF
--- a/src/plugin/server.js
+++ b/src/plugin/server.js
@@ -27,7 +27,7 @@ const client = join(__dirname, "../../bin/client");
 exports.io = io;
 
 if (process.env.NODE_ENV !== "jarvis_dev") {
-  app.use(statics(client));
+  app.get("*", statics(client));
 } else {
   app.get("/", (_, res) => {
     res.end(`Jarvis client is running on: ${PORT}`);


### PR DESCRIPTION
I gotta look into something for Polka & see why this was happening with the `.use()` global handler. I have some ideas~

This fixes it for now. I will update/revert when Polka fixes the syntax.

```sh
$ yarn
$ yarn dev
#=> open to localhost:1337
```

<img width="519" alt="screen shot 2018-02-01 at 1 08 08 pm" src="https://user-images.githubusercontent.com/5855893/35703621-91007638-0751-11e8-92de-1923bc20fa91.png">
