### PR TITLE
Make an explicit dist folder, rather than using lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,7 @@ yarn.lock
 # misc
 .DS_*
 .idea/
-lib
-lib/bundle.js
-lib/style.css
+dist
 .DS_Store
 .idea
 .vscode

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -9,7 +9,7 @@ const babel = require("./babel");
 const styles = require("./style");
 const uglify = require("./uglify");
 
-const dist = join(__dirname, "../lib");
+const dist = join(__dirname, "../dist");
 
 module.exports = env => {
   const isProd = env && env.production;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A very intelligent webpack dashboard",
   "main": "lib/server/index.js",
   "files": [
-    "lib"
+    "dist"
   ],
   "scripts": {
     "precommit": "lint-staged",


### PR DESCRIPTION
### What changes are you making...
bugfix for https://github.com/zouhir/jarvis/issues/123

### What is the current behavior?
Currently `lib` is both a src and dist folder, which definitely confuses IDEs, and almost certainly confuses developers

### What is the new behavior?
`dist` is the new dist folder, and `lib` is a purely src folder

### Are you making a breaking change?
Possibly, if people were explicitly depending on the location of the generated files? Not sure if this is something people are actually doing in the wild